### PR TITLE
🩹 `Ajuste conteúdo - Footer` 

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -11,9 +11,11 @@ export default function RootLayout({ children }) {
   return (
     <html lang="pt-br">
       <body className="font-verdana h-[100dvh]">
-        <div className="flex flex-col p-0 w-full min-h-screen">
+        <div className="flex flex-col min-h-screen">
           <Navbar />
-          {children}
+          <div className="flex-1">
+            {children}
+          </div>
           <Footer />
         </div>
       </body>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/596bbe98-ad06-40b9-aa79-7aa449c00b20)
footer agora fica grudada no bottom da tela