### PR TITLE
Feature/adiciona url backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
-PORT=
-API_URL=
+PORT=3000
+NEXT_PUBLIC_BACKEND_URL=http://localhost:3001/
+
+# Variaveis utilizadas no frontend (nos componentes por exemplo) precisam iniciar com NEXT_PUBLIC

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 PORT=3000
-NEXT_PUBLIC_BACKEND_URL=http://localhost:3001/
+NEXT_PUBLIC_API_URL=http://localhost:3001/
 
 # Variaveis utilizadas no frontend (nos componentes por exemplo) precisam iniciar com NEXT_PUBLIC

--- a/src/app/votacao/interna/confirmacao/page.js
+++ b/src/app/votacao/interna/confirmacao/page.js
@@ -13,6 +13,39 @@ const ConfirmationPage = () => {
     modalRef.current.openModal();
   };
 
+  const confirmVote = async () => {
+    try {
+      console.log("Iniciando o processo de confirmação de voto...");
+      const response = await fetch(
+        "http://localhost/votacao/interna/confirmacao",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            idAluno: 123, 
+            idCandidato: 456,
+            idEvento: 789,
+          }),
+        }
+      );
+
+      console.log("Resposta recebida do servidor:", response);
+
+      if (!response.ok) {
+        console.error("Erro na resposta do servidor:", response.statusText);
+        throw new Error("Erro ao registrar o voto.");
+      }
+
+      console.log("Voto confirmado com sucesso!");
+      return "Voto confirmado com sucesso!";
+    } catch (error) {
+      console.error("Erro ao confirmar o voto:", error);
+      throw error.message;
+    }
+  };
+
   const description = "verifique ao lado se o candidato é o desejado e confirme logo abaixo. Em breve atualizaremos você sobre o resultado da votação e quem serão os novos representanetes de sua turma!"
 
   return (
@@ -35,7 +68,7 @@ const ConfirmationPage = () => {
           textButton={"CONFIRMAR VOTO"}
         />
       </div>
-      <ConfirmModal ref={modalRef} />
+      <ConfirmModal ref={modalRef} onConfirm={confirmVote} />
     </>
   );
 };

--- a/src/app/votacao/interna/confirmacao/page.js
+++ b/src/app/votacao/interna/confirmacao/page.js
@@ -16,22 +16,23 @@ const ConfirmationPage = () => {
   const confirmVote = async () => {
     try {
       console.log("Iniciando o processo de confirmação de voto...");
+      
       const response = await fetch(
-        "http://localhost/votacao/interna/confirmacao",
+        `${process.env.NEXT_PUBLIC_API_URL}/votacao/interna/confirmacao`,
         {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            idAluno: 123, 
-            idCandidato: 456,
-            idEvento: 789,
+            idAluno: 1, 
+            idCandidato: 1,
+            idEvento: 1,
           }),
         }
       );
 
-      console.log("Resposta recebida do servidor:", response);
+      console.log("Resposta recebida do servidor:", await response.json());
 
       if (!response.ok) {
         console.error("Erro na resposta do servidor:", response.statusText);

--- a/src/app/votacao/publica/confirmacao/avaliador/classificacao/page.js
+++ b/src/app/votacao/publica/confirmacao/avaliador/classificacao/page.js
@@ -37,6 +37,40 @@ export default function RatingPage() {
   const [inovacao, setInovacao] = useState({ rating: null, comentario: "" });
   const [isCommentOpen, setIsCommentOpen] = useState(false);
 
+  const confirmVote = async () => {
+    console.log("Iniciando o envio da avaliação...");
+    try {
+      const payload = {
+        id_avaliador: 2,
+        id_projeto: 200,
+        estrelas: acolhimento.rating || inovacao.rating,
+      };
+      console.log("Payload da requisição:", payload);
+
+      const response = await fetch(
+        "http://localhost/votacao/publica/confirmacao/avaliador/classificacao",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      console.log("Resposta da requisição recebida:", response);
+
+      if (!response.ok) {
+        throw new Error("Erro ao enviar a avaliação");
+      }
+
+      console.log("Avaliação enviada com sucesso!");
+      modalRef.current.openModal();
+    } catch (error) {
+      console.error("Erro na requisição:", error);
+    }
+  };
+
   const handleNextStep = () => {
     if (step === 0) {
       setStep(1);
@@ -127,7 +161,7 @@ export default function RatingPage() {
           </div>
         </div>
       </div>
-      <ConfirmModal ref={modalRef} />
+      <ConfirmModal ref={modalRef} onConfirm={confirmVote} />
     </>
   );
 }

--- a/src/app/votacao/publica/confirmacao/avaliador/classificacao/page.js
+++ b/src/app/votacao/publica/confirmacao/avaliador/classificacao/page.js
@@ -41,14 +41,14 @@ export default function RatingPage() {
     console.log("Iniciando o envio da avaliação...");
     try {
       const payload = {
-        id_avaliador: 2,
-        id_projeto: 200,
+        id_avaliador: 3,
+        id_projeto: 1,
         estrelas: acolhimento.rating || inovacao.rating,
       };
       console.log("Payload da requisição:", payload);
 
       const response = await fetch(
-        "http://localhost/votacao/publica/confirmacao/avaliador/classificacao",
+        `${process.env.NEXT_PUBLIC_API_URL}/votacao/publica/confirmacao/avaliador/classificacao`,
         {
           method: "POST",
           headers: {
@@ -58,7 +58,7 @@ export default function RatingPage() {
         }
       );
 
-      console.log("Resposta da requisição recebida:", response);
+      console.log("Resposta da requisição recebida:", await response.json());
 
       if (!response.ok) {
         throw new Error("Erro ao enviar a avaliação");

--- a/src/app/votacao/publica/confirmacao/convidado/page.js
+++ b/src/app/votacao/publica/confirmacao/convidado/page.js
@@ -13,6 +13,40 @@ export default function VotacaoPublica() {
     modalRef.current.openModal();
   };
 
+  const confirmVote = async () => {
+    console.log("Iniciando o processo de confirmação de voto...");
+    try {
+      const payload = {
+        id_visitante: 1,
+        id_candidato: 45,
+        id_evento: 2,
+      };
+      console.log("Payload a ser enviado:", payload);
+
+      const response = await fetch(
+        "http://localhost/votacao/publica/confirmacao/convidado",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(payload),
+        }
+      );
+
+      console.log("Resposta recebida do servidor:", response);
+
+      if (!response.ok) {
+        throw new Error("Erro ao enviar a avaliação");
+      }
+
+      console.log("Voto confirmado com sucesso!");
+      modalRef.current.openModal();
+    } catch (error) {
+      console.error("Erro na requisição:", error);
+    }
+  };
+
   return (
     <>
       <Header text={"PROJETO"} />
@@ -28,7 +62,7 @@ export default function VotacaoPublica() {
           textButton={"VOTAR"}
         />
       </div>
-      <ConfirmModal ref={modalRef} />
+      <ConfirmModal ref={modalRef} onConfirm={confirmVote} />
     </>
   );
 }

--- a/src/app/votacao/publica/confirmacao/convidado/page.js
+++ b/src/app/votacao/publica/confirmacao/convidado/page.js
@@ -18,13 +18,13 @@ export default function VotacaoPublica() {
     try {
       const payload = {
         id_visitante: 1,
-        id_candidato: 45,
+        id_candidato: 1,
         id_evento: 2,
       };
       console.log("Payload a ser enviado:", payload);
 
       const response = await fetch(
-        "http://localhost/votacao/publica/confirmacao/convidado",
+        `${process.env.NEXT_PUBLIC_API_URL}/votacao/publica/confirmacao/convidado`,
         {
           method: "POST",
           headers: {
@@ -34,7 +34,7 @@ export default function VotacaoPublica() {
         }
       );
 
-      console.log("Resposta recebida do servidor:", response);
+      console.log("Resposta recebida do servidor:", await response.json());
 
       if (!response.ok) {
         throw new Error("Erro ao enviar a avaliação");

--- a/src/components/confirmModal.js
+++ b/src/components/confirmModal.js
@@ -7,8 +7,9 @@ import React, {
 import FeedbackModal from "./feedbackModal";
 import Button from "./button";
 
-const ConfirmModal = forwardRef((_, ref) => {
+const ConfirmModal = forwardRef(({ onConfirm }, ref) => {
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
   const modalRef = useRef(null);
 
   useImperativeHandle(ref, () => ({
@@ -18,30 +19,28 @@ const ConfirmModal = forwardRef((_, ref) => {
     closeModal: () => setIsConfirmOpen(false),
   }));
 
-  // Simulação de chamada de API
-  const mockApiCall = () => {
-    return new Promise((resolve, reject) => {
-      setTimeout(() => {
-        const success = Math.random() > 0.5; // 50% chance de sucesso
-        success
-          ? resolve("Voto confirmado com sucesso!")
-          : reject("Erro ao confirmar o voto.");
-      }, 100);
-    });
-  };
-
   const handleConfirm = async () => {
+    console.log("handleConfirm: Início");
+    setLoading(true);
     setIsConfirmOpen(false);
 
     try {
-      const successMessage = await mockApiCall();
+      console.log("handleConfirm: Chamando onConfirm");
+      const successMessage = await onConfirm(); // Chama a API correta passada na tela
+      console.log("handleConfirm: onConfirm concluído com sucesso, mensagem:", successMessage);
       setTimeout(() => {
+        console.log("handleConfirm: Abrindo FeedbackModal com mensagem de sucesso");
         modalRef.current?.openModal(successMessage);
       }, 100);
     } catch (errorMessage) {
+      console.error("handleConfirm: onConfirm falhou, mensagem de erro:", errorMessage);
       setTimeout(() => {
+        console.log("handleConfirm: Abrindo FeedbackModal com mensagem de erro");
         modalRef.current?.openModal(errorMessage);
       }, 100);
+    } finally {
+      console.log("handleConfirm: Fim");
+      setLoading(false);
     }
   };
 
@@ -52,13 +51,20 @@ const ConfirmModal = forwardRef((_, ref) => {
           <div className="flex flex-col items-center justify-center">
             <div className="bg-white p-6 rounded-xl shadow-lg text-center border-4 border-[#B20000] md:w-lg md:max-w-lg w-[308px]">
               <p className="text-lg">
-                Tem certeza de que deseja confirmar o voto?
+                {loading
+                  ? "Confirmando voto..."
+                  : "Tem certeza de que deseja confirmar o voto?"}
               </p>
             </div>
-            <div className="flex gap-4 md:gap-9 mt-4 md:gap">
-              <Button onClick={() => setIsConfirmOpen(false)} text={"VOLTAR"}/>
-              <Button onClick={handleConfirm} text={"CONFIRMAR"}/>
-            </div>
+            {!loading && (
+              <div className="flex gap-4 md:gap-9 mt-4">
+                <Button
+                  onClick={() => setIsConfirmOpen(false)}
+                  text={"VOLTAR"}
+                />
+                <Button onClick={handleConfirm} text={"CONFIRMAR"} />
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
Adicionado e testado o uso da API do backend.
- Adicionado o uso de variáveis de ambiente.
- Todas as requisições estão apontando para a API.
- - Os dados mockados foram alterados para coincidir com os dados de testes do banco de dados que você gera ao configurar a API do backend.

Observação:
- Para conseguir realizar as chamadas para a API, é necessário que o servidor do backend esteja devidamente configurado ([votacao-be: readme](https://github.com/laboratorio-de-praticas/votacao-be/blob/develop/README.md)).
- Nova variável de ambiente: _NEXT_PUBLIC_BACKEND_URL_.
- Algumas telas não conseguem lidar com erros provindos das requisições, aconselho o consumo das mensagens que a API devolve (se o erro estiver mapeado do lado deles, claro).
- - Se a requisição conseguiu ser realizada com sucesso (não estourou uma exceção), você pode obter a resposta da rota com o _await response.json()_.
- - Você pode conferir as possíveis respostas olhando a documentação _Swagger_ da API do backend.