### PR TITLE
Refactor: Remover o componente `CongratsText` da página de confirmação

### DIFF
--- a/src/app/votacao/interna/confirmacao/page.js
+++ b/src/app/votacao/interna/confirmacao/page.js
@@ -5,7 +5,7 @@ import ConfirmModal from "@/components/confirmModal";
 import Header from "@/components/header";
 import CongratsText from "@/components/congratsText";
 import CandidateCard from "@/components/candidateCard";
-import Button from "@/components/button";
+
 
 const ConfirmationPage = () => {
   const modalRef = useRef();
@@ -62,11 +62,6 @@ const ConfirmationPage = () => {
     <>
       <Header text={"REPRESENTANTES"} />
       <div className="flex flex-col md:flex-row md:w-5/6 gap-8 mt-6 md:gap-12 md:mt-16 md:mb-16 md:justify-stretch md:self-center">
-        <CongratsText
-          text={description}
-          onClickItem={handleConfirm}
-          textButton={"VOTAR"}
-        />
         <div className=" md:order-1 md:col-start-1 md:row-span-2 flex justify-center">
           <CandidateCard
             mobileImage="/placeholder_mobile.png"


### PR DESCRIPTION
Este PR remove o componente `CongratsText` da página de confirmação, pois ocasionava um erro de duplicação de componente na tela da rota `votacao\interna\confirmacao`

**Notas adicionais:**  
- Nenhuma alteração visual foi introduzida; a UI permanece idêntica para o usuário.  
- Testes manuais foram realizados para garantir o funcionamento correto da página de confirmação.  